### PR TITLE
Feature/pass service accounts to workflow steps

### DIFF
--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -292,6 +292,9 @@ class ZooCalrissianRunner:
         self.inputs = ZooInputs(inputs)
         self.outputs = ZooOutputs(outputs)
         self.cwl = Workflow(cwl, self.zoo_conf.workflow_id)
+        self.calling_workspace = inputs["calling_workspace"]["value"]
+        self.executing_workspace = inputs["executing_workspace"]["value"]
+        self.job_id = conf["lenv"]["usid"]
 
         self.handler = execution_handler
 
@@ -422,6 +425,9 @@ class ZooCalrissianRunner:
             storage_class=self.storage_class,
             volume_size=self.get_volume_size(),
             image_pull_secrets=secret_config,
+            calling_workspace=self.calling_workspace,
+            executing_workspace=self.executing_workspace,
+            job_id=self.job_id,
             calling_service_account=self.zoo_conf.conf.get("eodhp", {}).get(
                 "serviceAccountNameCalling", "default"
             ),
@@ -476,6 +482,9 @@ class ZooCalrissianRunner:
             debug=True,
             no_read_only=True,
             tool_logs=True,
+            calling_workspace=self.calling_workspace,
+            executing_workspace=self.executing_workspace,
+            job_id=self.job_id,
         )
 
         self.update_status(progress=23, message="execution submitted")

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -422,6 +422,9 @@ class ZooCalrissianRunner:
             storage_class=self.storage_class,
             volume_size=self.get_volume_size(),
             image_pull_secrets=secret_config,
+            calling_service_account=self.zoo_conf.conf.get("eodhp", {}).get(
+                "serviceAccountNameCalling", "default"
+            ),
         )
         session.initialise()
         self.update_status(progress=15, message="processing environment created, preparing execution")


### PR DESCRIPTION
## Handle Service Accounts for User Services
- Pass service account name through to Pycalrissian
- Align this repo with the UKEODHP organisation repository
- Add workspace and job_id inputs